### PR TITLE
add alpine image

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,0 +1,19 @@
+FROM node:carbon-alpine
+
+WORKDIR /opt/PlexIPTV
+
+RUN mkdir -p ./config
+VOLUME ["/opt/PlexIPTV/config"]
+
+COPY package*.json ./
+COPY yarn.lock ./
+
+RUN yarn --production
+
+COPY . .
+
+RUN sed -i 's/iptv.m3u8/config\/iptv.m3u8/g' template.json
+
+EXPOSE 1245
+
+CMD [ "npm", "run", "start:docker" ]


### PR DESCRIPTION
This reduces the docker image by 606MB.

```
REPOSITORY              TAG                 IMAGE ID            CREATED              SIZE
xiaodoudoufr/plexiptv   alpine              6c1af981336d        About a minute ago   184MB
node                    carbon-alpine       8dc87c93a9ee        3 days ago           68MB
xiaodoudoufr/plexiptv   latest              63402b122d10        3 weeks ago          790MB
```