### PR TITLE
fix: correct 'Sucessfully saved' to 'Successfully saved' in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ class Server {
           if (error) {
             deferred.reject(error)
           } else {
-            Logger.info(`Sucessfully saved playlist to: ${this.settings.m3u8.local}`)
+            Logger.info(`Successfully saved playlist to: ${this.settings.m3u8.local}`)
             deferred.resolve(body)
           }
         })


### PR DESCRIPTION
Fixes: corrects the typo 'Sucessfully saved' to 'Successfully saved' in the playlist save log message (index.js line 146).